### PR TITLE
Fix to use absolute path

### DIFF
--- a/class.Track.php
+++ b/class.Track.php
@@ -81,7 +81,7 @@ Abstract Class Track {
         } else {
             self::$dir = $dir.DS;
         }
-        $path = dirname($_SERVER['SCRIPT_FILENAME']).DS.self::$dir;
+        $path = $dir; //dirname($_SERVER['SCRIPT_FILENAME']).DS.self::$dir;
         if (!is_dir($path)) {   
             if (!mkdir($path, 0766, true)) {    
                 print('Cannot create log directory'."\n");  


### PR DESCRIPTION
Fixed so that the class receives an absolute path instead of directory.
Changed: 
$path = $dir on line 84